### PR TITLE
add integration test package object with helper functions.

### DIFF
--- a/src/test/scala/org/catapult/sa/fulgurite/integration/TestReading.scala
+++ b/src/test/scala/org/catapult/sa/fulgurite/integration/TestReading.scala
@@ -1,22 +1,18 @@
 package org.catapult.sa.fulgurite.integration
 
-import org.apache.spark.SparkContext
-import org.catapult.sa.fulgurite.examples._
 import org.catapult.sa.fulgurite.geotiff.GeoTiffMeta
 import org.catapult.sa.fulgurite.spark.GeoSparkUtils
-import org.junit.Test
 import org.junit.Assert._
+import org.junit.Test
 
 /**
-  * A bunch of quite big tests to
+  * A big test to make sure that reading works as expected.
   */
 class TestReading {
 
   @Test
   def basicReadingTest(): Unit = {
-
-    val conf = createConfig("basicReadingTest", "local[2]")
-    val sc = SparkContext.getOrCreate(conf)
+    val sc = getSparkContext("basicReadingTest", "local[2]")
 
     val metaData = GeoTiffMeta("src/test/resources/data_chunked.tif")
     val result = GeoSparkUtils.GeoTiffRDD("src/test/resources/data_chunked.tif", metaData, sc, 10 )
@@ -26,7 +22,5 @@ class TestReading {
     val expected = (0 until 11).flatMap(y => (0 until 11).flatMap(x => List(255, 128, 0))).toArray
 
     assertArrayEquals(expected, result)
-
   }
-
 }

--- a/src/test/scala/org/catapult/sa/fulgurite/integration/TestWriting.scala
+++ b/src/test/scala/org/catapult/sa/fulgurite/integration/TestWriting.scala
@@ -4,10 +4,8 @@ import java.io.{File, FileInputStream}
 
 import com.github.jaiimageio.plugins.tiff.BaselineTIFFTagSet
 import org.apache.commons.io.{FileUtils, IOUtils}
-import org.apache.spark.SparkContext
 import org.catapult.sa.fulgurite.geotiff.{GeoTiffMeta, Index}
 import org.catapult.sa.fulgurite.spark.GeoSparkUtils
-import org.catapult.sa.fulgurite.examples._
 import org.junit.Assert._
 import org.junit.Test
 
@@ -24,8 +22,7 @@ class TestWriting {
     val outputName = FileUtils.getTempDirectoryPath + "/tmp" + Random.nextInt()
     new File(outputName).deleteOnExit()
 
-    val conf = createConfig("TestWriting", "local[2]")
-    val sc = SparkContext.getOrCreate(conf)
+    val sc = getSparkContext("TestWriting", "local[2]")
 
     val metaData = GeoTiffMeta("src/test/resources/data_chunked.tif")
 
@@ -49,8 +46,7 @@ class TestWriting {
     val outputName = FileUtils.getTempDirectoryPath + "/tmp" + Random.nextInt()
     new File(outputName).deleteOnExit()
 
-    val conf = createConfig("TestWriting", "local[2]")
-    val sc = SparkContext.getOrCreate(conf)
+    val sc = getSparkContext("TestWriting", "local[2]")
 
     val meta = GeoTiffMeta("src/test/resources/data_chunked.tif") // Blarg get hold of base meta.
 
@@ -82,8 +78,7 @@ class TestWriting {
     val outputName = FileUtils.getTempDirectoryPath + "/tmp" + Random.nextInt()
     new File(outputName).deleteOnExit()
 
-    val conf = createConfig("TestWriting", "local[2]")
-    val sc = SparkContext.getOrCreate(conf)
+    val sc = getSparkContext("TestWriting", "local[2]")
 
     val meta = GeoTiffMeta("src/test/resources/data_chunked.tif") // Blarg get hold of base meta.
 

--- a/src/test/scala/org/catapult/sa/fulgurite/integration/package.scala
+++ b/src/test/scala/org/catapult/sa/fulgurite/integration/package.scala
@@ -1,0 +1,29 @@
+package org.catapult.sa.fulgurite
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.catapult.sa.fulgurite.geotiff.Index
+
+/**
+  * Utility methods to make tests easier.
+  *
+  * This is similar to the example one but means we can safely split the config for testing and we don't have to include
+  * things in the examples to be able to run the tests.
+  */
+package object integration {
+  /**
+    * Create a default spark config. Making sure that compression is turned on and kryo is set up with the Index class
+    * @param appName Name of this application
+    * @param master name of the master
+    * @return result config
+    */
+  def createConfig(appName : String, master : String = "local[*]") = new SparkConf()
+    .setAppName(appName)
+    .setMaster(master)
+    .set("spark.rdd.compress", "true")
+    .set("spark.io.compression.codec", "lz4")
+    .set("spark.io.compression.lz4.blockSize", "16K")
+    .registerKryoClasses(Array(classOf[Index]))
+
+  def getSparkContext(appName : String, master : String = "local[*]") =
+    SparkContext.getOrCreate(createConfig(appName, master))
+}


### PR DESCRIPTION
This splits the dependency from the tests on the examples.
